### PR TITLE
Update M1 Setup Instructions

### DIFF
--- a/docs/getting-started/M1.md
+++ b/docs/getting-started/M1.md
@@ -115,16 +115,9 @@ Starship is a simple and customizable shell prompt. Follow the [Quick Install](h
 
 ### Install Python
 
-We recommend installing Python from the [python.org Downloads page](https://www.python.org/downloads/). After running through the installation, don't forget to
+We recommend installing Python from the [python.org Downloads page](https://www.python.org/downloads/).
 
-1. double click on the Install Certificates.command icon in Finder (in the folder for the new Python installation) to install a set of SSL root certificates.
-
-2. Add the new Python to your `~/.zshrc`. For example, for Python3.11:
-
-    ```shell
-    # Add Python 3.11 to the PATH.
-    export PATH="/Library/Frameworks/Python.framework/Versions/3.11/bin:$PATH"
-    ```
+After running through the installation, don't forget to double click on the Install Certificates.command icon in Finder (in the folder for the new Python installation) to install a set of SSL root certificates.
 
 Note: you may instead use a Python manager (like pyenv) to manager versions of Python, if you prefer, though our experience with them has not been as good as downloading Python from python.org.
 

--- a/docs/getting-started/M1.md
+++ b/docs/getting-started/M1.md
@@ -201,6 +201,8 @@ Even if you don't run the PostgreSQL service, it can be helpful to install the C
 HOMEBREW_NO_AUTO_UPDATE=1 brew install postgresql
 ```
 
+Note: See [From Caktus With Love](../reference/from-caktus-with-love.md) for more information on `HOMEBREW_NO_AUTO_UPDATE=1`.
+
 ### Install Docker
 
 Visit https://docs.docker.com/desktop/mac/install/ and click the _Mac with Apple chip_ blue button, then:

--- a/docs/getting-started/M1.md
+++ b/docs/getting-started/M1.md
@@ -87,8 +87,10 @@ Then add `brew` to your PATH:
 echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.zshrc
 ```
 
-Note:
-It seems that Homebrew packages have now generally added support for arm64. However, it is possible that you may encounter a package that does not. If you find yourself in that scenario, it is possible to support running both native arm64 and x86-emulated homebrew packages, by installing an x86-emulated homebrew side-by-side. See [Colin's blog post](https://www.caktusgroup.com/blog/2021/04/02/python-django-react-development-apple-silicon/#install-homebrew "Python Django React Apple Silicon") for an example.
+!!! note
+
+
+    It seems that Homebrew packages have now generally added support for arm64. However, it is possible that you may encounter a package that does not. If you find yourself in that scenario, it is possible to support running both native arm64 and x86-emulated homebrew packages, by installing an x86-emulated homebrew side-by-side. See [Colin's blog post](https://www.caktusgroup.com/blog/2021/04/02/python-django-react-development-apple-silicon/#install-homebrew "Python Django React Apple Silicon") for an example.
 
 
 ### Install openssl
@@ -119,7 +121,9 @@ We recommend installing Python from the [python.org Downloads page](https://www.
 
 After running through the installation, don't forget to double click on the Install Certificates.command icon in Finder (in the folder for the new Python installation) to install a set of SSL root certificates.
 
-Note: you may instead use a Python manager (like pyenv) to manager versions of Python, if you prefer, though our experience with them has not been as good as downloading Python from python.org.
+!!! note
+
+    You may instead use a Python manager (like pyenv) to manager versions of Python, if you prefer, though our experience with them has not been as good as downloading Python from python.org.
 
 ### Install direnv
 
@@ -159,7 +163,9 @@ Even if you don't run the PostgreSQL service, it can be helpful to install the C
 HOMEBREW_NO_AUTO_UPDATE=1 brew install postgresql
 ```
 
-Note: See [From Caktus With Love](../reference/from-caktus-with-love.md) for more information on `HOMEBREW_NO_AUTO_UPDATE=1`.
+!!! note
+
+    See [From Caktus With Love](../reference/from-caktus-with-love.md) for more information on `HOMEBREW_NO_AUTO_UPDATE=1`.
 
 ### Install Docker
 

--- a/docs/getting-started/M1.md
+++ b/docs/getting-started/M1.md
@@ -73,7 +73,7 @@ To associate your `git` commits to your GitHub account, we will set your [name](
 
 ### Homebrew
 
-Homebrew does [support Apple Silicon](https://brew.sh/2020/12/01/homebrew-2.6.0/). However, a particular package may not run natively, so your mileage may vary. To support running both native arm64 and x86-emulated homebrew packages, you install them side-by-side.
+Homebrew does [support Apple Silicon](https://brew.sh/2020/12/01/homebrew-2.6.0/).
 
 Install arm64 ``brew`` into ``/opt/homebrew``:
 
@@ -86,6 +86,10 @@ Then add `brew` to your PATH:
 ```shell
 echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.zshrc
 ```
+
+Note:
+It seems that Homebrew packages have now generally added support for arm64. However, it is possible that you may encounter a package that does not. If you find yourself in that scenario, it is possible to support running both native arm64 and x86-emulated homebrew packages, by installing an x86-emulated homebrew side-by-side. See [Colin's blog post](https://www.caktusgroup.com/blog/2021/04/02/python-django-react-development-apple-silicon/#install-homebrew "Python Django React Apple Silicon") for an example.
+
 
 ### Install openssl
 

--- a/docs/getting-started/M1.md
+++ b/docs/getting-started/M1.md
@@ -241,7 +241,7 @@ load-nvmrc
 # Add homebrew to path
 export PATH="/opt/homebrew/bin:$PATH"
 
-# C-lib complication flags
+# C-lib compilation flags
 export LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix zlib)/lib"
 export CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix zlib)/include"
 

--- a/docs/getting-started/M1.md
+++ b/docs/getting-started/M1.md
@@ -113,20 +113,20 @@ Starship is a simple and customizable shell prompt. Follow the [Quick Install](h
     - **Visual Studio Code**: Open *Code → Preferences → Settings* (Mac), enter `terminal.integrated.fontFamily` in the search box at the top of *Settings* ta and set the value below to your Nerd Font.
 
 
-### Install pyenv
+### Install Python
 
-```
-brew install pyenv
-```
+We recommend installing Python from the [python.org Downloads page](https://www.python.org/downloads/). After running through the installation, don't forget to
 
-Add the following to the bottom of your `.zshrc`:
+1. double click on the Install Certificates.command icon in Finder (in the folder for the new Python installation) to install a set of SSL root certificates.
 
-```shell
-eval "$(pyenv init -)"
-eval "$(pyenv init --path)"
-eval "$(/opt/homebrew/bin/brew shellenv)"
-```
+2. Add the new Python to your `~/.zshrc`. For example, for Python3.11:
 
+    ```shell
+    # Add Python 3.11 to the PATH.
+    export PATH="/Library/Frameworks/Python.framework/Versions/3.11/bin:$PATH"
+    ```
+
+Note: you may instead use a Python manager (like pyenv) to manager versions of Python, if you prefer, though our experience with them has not been as good as downloading Python from python.org.
 
 ### Install direnv
 
@@ -146,45 +146,10 @@ Then edit that file and add the following to it using your favorite text editor,
 the following.
 
 ```shell
-# use a certain pyenv version
-use_python() {
-    if [ -n "$(which pyenv)" ]; then
-        local pyversion=$1
-        pyenv local ${pyversion}
-    fi
-}
 
 use_cluster() {
     kubectl config use-context "$1"
 }
-
-layout_virtualenv() {
-    local pyversion=$1
-    local pvenv=$2
-    if [ -n "$(which pyenv virtualenv)" ]; then
-        pyenv virtualenv --force --quiet ${pyversion} ${pvenv}-${pyversion}
-    fi
-    pyenv local --unset
-}
-
-layout_activate() {
-    if [ -n "$(which pyenv)" ]; then
-        source $(pyenv root)/versions/$1/bin/activate
-    fi
-}
-
-```
-
-### Install pyenv
-
-Next install a new version of python for example:
-
-```shell
-pyenv install --list
-```
-
-```shell
-pyenv install 3.9.2
 ```
 
 Add the following lines to your `~/.zshrc`:
@@ -250,11 +215,6 @@ export CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix zlib)/incl
 # Hook in direnv
 eval "$(direnv hook zsh)"
 
-# pyenv
-eval "$(pyenv init -)"
-eval "$(pyenv init --path)"
-eval "$(/opt/homebrew/bin/brew shellenv)"
-```
 
 After adding this to your `.zshrc`, source the file to make it available to your current 
 environment.


### PR DESCRIPTION
I recently set up an M1 MacBook using these instructions, and am making a few changes to the docs:
 - installing an x86 Homebrew is probably not necessary anymore, so I changed the wording to not tell people to install it
 - I replaced mentions of pyenv with telling people to use python.org to install Python
 - I corrected a misspelled word
